### PR TITLE
Fixed mProgressBarLoadMore didn't disappear on PullAndLoadListView

### DIFF
--- a/pulltorefresh-and-loadmore/src/com/costum/android/widget/PullAndLoadListView.java
+++ b/pulltorefresh-and-loadmore/src/com/costum/android/widget/PullAndLoadListView.java
@@ -118,6 +118,7 @@ public class PullAndLoadListView extends PullToRefreshListView {
 	 */
 	public void onLoadMoreComplete() {
 		mIsLoadingMore = false;
+		mProgressBarLoadMore.setVisibility(View.GONE);
 	}
 
 	/**


### PR DESCRIPTION
Added one line to set visibility gone for progress bar, just as the LoadMoreListView.
